### PR TITLE
Add fuzzywuzzy 0.18.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,17 +15,16 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: "{{ PYTHON }} -m pip install . -vv"
+  script: {{ PYTHON }} -m pip install . -vv
   
-
 requirements:
   host:
-    - python >=2.7
+    - python
     - pip
-
+    - setuptools
+    - wheel
   run:
-    - python >=2.7
+    - python
     - python-levenshtein >=0.12
 
 test:
@@ -36,6 +35,10 @@ test:
     - fuzzywuzzy.process
     - fuzzywuzzy.string_processing
     - fuzzywuzzy.utils
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/seatgeek/fuzzywuzzy
@@ -44,7 +47,7 @@ about:
   license_file: LICENSE.txt
   summary: 'Fuzzy string matching in python'
   dev_url: https://github.com/seatgeek/fuzzywuzzy
-  doc_url: http://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/
+  doc_url: https://chairnerd.seatgeek.com/fuzzywuzzy-fuzzy-string-matching-in-python/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: 0
+  # Currently python-levenshtein isn't available on s390x
+  skip: True  # [s390x]
   script: {{ PYTHON }} -m pip install . -vv
   
 requirements:


### PR DESCRIPTION
Changelog: https://github.com/seatgeek/fuzzywuzzy/blob/master/CHANGES.rst
License: https://github.com/seatgeek/fuzzywuzzy/blob/0.18.0/LICENSE.txt
Requirements: https://github.com/seatgeek/fuzzywuzzy/blob/0.18.0/setup.py

Actions:
1. Remove `noarch`
2. Skip `s390x`
3. Add missing packages `setuptools`, `wheel`
4. Fix `python` in run and host
5. Add `pip check`
6. Fix `doc_url` with HTTPS